### PR TITLE
Remove link to contributing.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # About
-We believe that showing what our model is capable of doing is important. For this reason, we created a web application using [Streamlit](https://streamlit.io/), where users can provide a repository URL, and we give the predictions for their CONTRIBUTING.md file. 
 
-If you are interested in our application, give it a look at: http://contributing.info/ (Last time available: 08/10/2022).
+We believe that showing what our model is capable of doing is important. For this reason, we created a web application using [Streamlit](https://streamlit.io/), where users can provide a repository URL, and we give the predictions for their `CONTRIBUTING.md` file. 
 
-This folder contains one of the first versions of our web application. Newer releases are being committed to: https://github.com/fronchetti/contributing.info/
-
+Check out the live version at <https://contribute.streamlit.app/>.


### PR DESCRIPTION
https://github.com/fronchetti/contributing.info/ redirects to https://github.com/fronchetti/contributing.streamlit.app and https://contributing.info/ is down. Thus, I propose to remove the links to there.